### PR TITLE
JOB-107839 Get updates from cookiejar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 - 2014, David Waite and Other Contributors
+Copyright (c) 2009 - 2018, David Waite and Other Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Ruby CookieJar
 Status
 ------
 
-This project is no longer maintained. There may be other gems more appropriate for use which support newer versions of the cookie specifications, or more maintained forks of this gem such as [https://github.com/dorianmariefr/cookiejar2](cookiejar2).
+This project is no longer maintained. There may be other gems more appropriate for use which support newer versions of the cookie specifications, or more maintained forks of this gem such as [cookiejar2](https://github.com/dorianmariefr/cookiejar2).
 
 Synopsis
 --------

--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,11 @@ Ruby CookieJar
 
 [![Build Status](https://travis-ci.org/dwaite/cookiejar.svg?branch=master)](https://travis-ci.org/dwaite/cookiejar)
 
+Status
+------
+
+This project is no longer maintained. There may be other gems more appropriate for use which support newer versions of the cookie specifications, or more maintained forks of this gem such as [https://github.com/dorianmariefr/cookiejar2](cookiejar2).
+
 Synopsis
 --------
 

--- a/cookiejar.gemspec
+++ b/cookiejar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ['--title', 'CookieJar -- Client-side HTTP Cookies']
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'rake', '>= 10.0', '< 13'
+  s.add_development_dependency 'rake', '>= 10.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard',  '~> 0.9.20'

--- a/cookiejar.gemspec
+++ b/cookiejar.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.name        = 'cookiejar'
   s.version     = CookieJar::VERSION
   s.authors     = ['David Waite']
+  s.license     = 'BSD-2-Clause'
   s.email       = ['david@alkaline-solutions.com']
   s.description = 'Allows for parsing and returning cookies in Ruby HTTP client code'
   s.summary     = 'Client-side HTTP Cookie library'

--- a/cookiejar.gemspec
+++ b/cookiejar.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ['--title', 'CookieJar -- Client-side HTTP Cookies']
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rake', '>= 10.0', '< 13'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'yard',  '~> 0.8', '>= 0.8.7'
+  s.add_development_dependency 'yard',  '~> 0.9.20'
   s.add_development_dependency 'bundler', '>= 0.9.3'
 end

--- a/lib/cookiejar/cookie.rb
+++ b/lib/cookiejar/cookie.rb
@@ -180,7 +180,7 @@ module CookieJar
                '/'
              else
                uri.path
-      end
+             end
       path_match   = path.start_with? @path
       secure_match = !(@secure && uri.scheme == 'http')
       script_match = !(script && @http_only)

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -45,7 +45,7 @@ module CookieJar
     HDN = /\A#{PATTERN::HOSTNAME}\Z/
     TOKEN = /\A#{PATTERN::TOKEN}\Z/
     PARAM1 = /\A(#{PATTERN::TOKEN})(?:=#{PATTERN::VALUE1})?\Z/
-    PARAM2 = Regexp.new "(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", '', 'n'
+    PARAM2 = Regexp.new("(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", Regexp::NOENCODING)
     # TWO_DOT_DOMAINS = /\A\.(com|edu|net|mil|gov|int|org)\Z/
 
     # Converts the input object to a URI (if not already a URI)

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -321,6 +321,8 @@ module CookieJar
             args[:secure] = true
           when :httponly
             args[:http_only] = true
+          when :samesite
+            args[:samesite] = keyvalue.downcase
           else
             fail InvalidCookieError, "Unknown cookie parameter '#{key}'"
           end

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -222,7 +222,7 @@ module CookieJar
                '/'
              else
                uri.path
-      end
+             end
 
       results = []
       hosts.each do |host|

--- a/lib/cookiejar/version.rb
+++ b/lib/cookiejar/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module CookieJar
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.4'.freeze
 end

--- a/spec/cookie_spec.rb
+++ b/spec/cookie_spec.rb
@@ -65,10 +65,10 @@ describe Cookie do
       expect(cookie.secure).to be_truthy
     end
     it 'should fail on unquoted paths' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie2 'https://www.google.com/a/blah',
                                 'GALX=RgmSftjnbPM;Path=/a/;Secure;Version=1'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should accept quoted values' do
       cookie = Cookie.from_set_cookie2 'http://localhost/', 'foo="bar";Version=1'

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -5,46 +5,46 @@ describe CookieValidation do
   describe '#validate_cookie' do
     localaddr = 'http://localhost/foo/bar/'
     it 'should fail if version unset' do
-      expect(lambda do
+      expect {
         unversioned = Cookie.from_set_cookie localaddr, 'foo=bar'
         unversioned.instance_variable_set :@version, nil
         CookieValidation.validate_cookie localaddr, unversioned
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is more specific' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/foo/bar/baz'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is different than the request' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/baz/'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the domain has no dots' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://zero/', 'foo=bar;domain=zero'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for explicit localhost' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;domain=localhost'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for mismatched domains' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://www.foo.com/', 'foo=bar;domain=bar.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for domains more than one level up' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://x.y.z.com/', 'foo=bar;domain=z.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for setting subdomain cookies' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://foo.com/', 'foo=bar;domain=auth.foo.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should handle a normal implicit internet cookie' do
       normal = Cookie.from_set_cookie 'http://foo.com/', 'foo=bar'


### PR DESCRIPTION
The original cookiejar gem has changes that makes it compatible with ruby 3.3. For our ruby upgrade, we should probably take those upgrades from cookiejar while preserving our hotfixes in it